### PR TITLE
Refactor GameManager for network implementation

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1083,7 +1083,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6925303888939187629, guid: 4719ced393551154ca1b317eed449d2d, type: 3}
       propertyPath: _isGlobal
-      value: 1
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6925303888939187629, guid: 4719ced393551154ca1b317eed449d2d, type: 3}
+      propertyPath: _isSpawnable
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6925303888939187629, guid: 4719ced393551154ca1b317eed449d2d, type: 3}
       propertyPath: WasActiveDuringEdit

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Splines;
 
-public class GameManager : BaseNetworkBehaviour
+public class GameManager : NetworkBehaviour
 {
     public enum GameState
     {
@@ -47,6 +47,28 @@ public class GameManager : BaseNetworkBehaviour
         {
             Instance = this;
         }
+        SetCurrentGameState(GameState.InMenu);
+    }
+
+    public override void OnStartNetwork()
+    {
+        base.OnStartNetwork();
+        MatchWin.OnChange += WinScreen;
+        GameOver.OnChange += GameOverScreen;
+    }
+
+    public override void OnStopClient()
+    {
+        base.OnStopClient();
+    }
+
+    private void UnregisterEvents()
+    {
+        MatchWin.OnChange -= WinScreen;
+        GameOver.OnChange -= GameOverScreen;
+        PlayerPresenter.OnPlayerSpawned -= HandlePlayerSpawned;
+        PlayerPresenter.OnPlayerSpawned -= _subscribeToPlayerPresenter;
+        wheelcartMovement.Completed -= () => Cmd_WinMatch();
     }
 
     private void _subscribeToPlayerPresenter(IHealthVariation playerHealthEvents)
@@ -105,21 +127,6 @@ public class GameManager : BaseNetworkBehaviour
     {
         Cursor.visible = value;
         Cursor.lockState = value ? CursorLockMode.None : CursorLockMode.Locked;
-    }
-
-    protected override void RegisterEvents()
-    {
-        SetCurrentGameState(GameState.InMenu);
-        MatchWin.OnChange += WinScreen;
-        GameOver.OnChange += GameOverScreen;
-    }
-
-    protected override void UnregisterEvents()
-    {
-        MatchWin.OnChange -= WinScreen;
-        GameOver.OnChange -= GameOverScreen;
-        wheelcartMovement.Completed -= () => Cmd_WinMatch();
-        PlayerPresenter.OnPlayerSpawned -= HandlePlayerSpawned;
     }
 
     public void SetCurrentGameState(GameState newState)


### PR DESCRIPTION
Updated the `GameManager` class to inherit from `NetworkBehaviour`, introducing new methods for network event handling such as `OnStartNetwork`, `OnStopClient`, and `UnregisterEvents`. Removed the old event registration methods to streamline the process. The `SetCurrentGameState` method is now called within `OnStartNetwork` to ensure proper state management. Additionally, modified prefab instance properties in `MainMenu.unity`, setting `_isGlobal` and `_isSpawnable` to `0` to adjust gameplay behavior.